### PR TITLE
feat: add input mask

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,4 @@
 #!/usr/bin/env sh
 . "$(dirname -- "$0")/_/husky.sh"
 
-npx tsc --noEmit && npx eslint . && npx prettier --write .
+npx tsc --noEmit && npx eslint . && npx prettier --write . && git add .

--- a/components/Input/hooks.ts
+++ b/components/Input/hooks.ts
@@ -1,7 +1,5 @@
 import { faUpload } from '@fortawesome/free-solid-svg-icons';
-import {
-  FontAwesomeIconProps,
-} from '@fortawesome/react-fontawesome';
+import { FontAwesomeIconProps } from '@fortawesome/react-fontawesome';
 import { useMemo, useState } from 'react';
 
 export interface InputProps {
@@ -13,7 +11,13 @@ export interface InputProps {
   placeholder: string;
 }
 
-export function useFileInput({ onChange, icon, type, label, placeholder }: InputProps) {
+export function useFileInput({
+  onChange,
+  icon,
+  type,
+  label,
+  placeholder,
+}: InputProps) {
   const isFileInput = useMemo(() => type === 'file', [type]);
   const [selectedFile, setSelectedFile] = useState<string | null>(null);
 
@@ -52,13 +56,13 @@ export function useFileInput({ onChange, icon, type, label, placeholder }: Input
       return 'Documento selecionado.';
     }
 
-    return placeholder
+    return placeholder;
   }, [selectedFile, placeholder]);
 
   return {
     renderedIcon,
     fileInputId,
     handleInputChange,
-    fileInputLabel
-  }
+    fileInputLabel,
+  };
 }

--- a/components/Input/hooks.ts
+++ b/components/Input/hooks.ts
@@ -1,10 +1,11 @@
+import { useMemo, useState } from 'react';
 import { faUpload } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIconProps } from '@fortawesome/react-fontawesome';
-import { useMemo, useState } from 'react';
 
 export interface InputProps {
   value?: string;
   label: string;
+  mask?: string | (string | RegExp)[];
   type: 'text' | 'email' | 'password' | 'number' | 'file';
   onChange?: (event: React.ChangeEvent<HTMLInputElement>) => void;
   icon?: FontAwesomeIconProps['icon'];

--- a/components/Input/hooks.ts
+++ b/components/Input/hooks.ts
@@ -1,0 +1,64 @@
+import { faUpload } from '@fortawesome/free-solid-svg-icons';
+import {
+  FontAwesomeIconProps,
+} from '@fortawesome/react-fontawesome';
+import { useMemo, useState } from 'react';
+
+export interface InputProps {
+  value?: string;
+  label: string;
+  type: 'text' | 'email' | 'password' | 'number' | 'file';
+  onChange?: (event: React.ChangeEvent<HTMLInputElement>) => void;
+  icon?: FontAwesomeIconProps['icon'];
+  placeholder: string;
+}
+
+export function useFileInput({ onChange, icon, type, label, placeholder }: InputProps) {
+  const isFileInput = useMemo(() => type === 'file', [type]);
+  const [selectedFile, setSelectedFile] = useState<string | null>(null);
+
+  const renderedIcon = useMemo(() => {
+    if (type === 'file') {
+      return faUpload;
+    }
+
+    return icon;
+  }, [icon, type]);
+
+  const handleInputChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    if (isFileInput) {
+      const file = event.target.files?.[0];
+
+      if (file) {
+        setSelectedFile(file.name);
+      } else {
+        setSelectedFile(null);
+      }
+    }
+
+    onChange?.(event);
+  };
+
+  const fileInputId = useMemo(() => {
+    if (isFileInput) {
+      return label.replaceAll(' ', '-').toLowerCase();
+    }
+
+    return undefined;
+  }, [isFileInput, label]);
+
+  const fileInputLabel = useMemo(() => {
+    if (selectedFile) {
+      return 'Documento selecionado.';
+    }
+
+    return placeholder
+  }, [selectedFile, placeholder]);
+
+  return {
+    renderedIcon,
+    fileInputId,
+    handleInputChange,
+    fileInputLabel
+  }
+}

--- a/components/Input/hooks.ts
+++ b/components/Input/hooks.ts
@@ -6,7 +6,7 @@ export interface InputProps {
   value?: string;
   label: string;
   mask?: string | (string | RegExp)[];
-  type: 'text' | 'email' | 'password' | 'number' | 'file';
+  type: 'text' | 'email' | 'password' | 'number' | 'file' | 'tel';
   onChange?: (event: React.ChangeEvent<HTMLInputElement>) => void;
   icon?: FontAwesomeIconProps['icon'];
   placeholder: string;

--- a/components/Input/index.tsx
+++ b/components/Input/index.tsx
@@ -1,10 +1,11 @@
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { useMemo } from 'react';
+import InputMask from 'react-input-mask';
 import { useFileInput, InputProps } from './hooks';
 import styles from './styles.module.css';
 
 function Input(props: InputProps) {
-  const { type, label, placeholder, value } = props;
+  const { type, label, placeholder, value, mask } = props;
   const isFileInput = useMemo(() => type === 'file', [type]);
 
   const { renderedIcon, fileInputId, handleInputChange, fileInputLabel } =
@@ -29,13 +30,24 @@ function Input(props: InputProps) {
             {fileInputLabel}
           </label>
         )}
-        <input
-          id={fileInputId}
-          type={type}
-          placeholder={placeholder}
-          value={value}
-          onChange={handleInputChange}
-        />
+
+        {mask ? (
+          <InputMask
+            mask={mask}
+            type={type}
+            value={value}
+            placeholder={placeholder}
+            onChange={handleInputChange}
+          />
+        ) : (
+          <input
+            id={fileInputId}
+            type={type}
+            placeholder={placeholder}
+            value={value}
+            onChange={handleInputChange}
+          />
+        )}
       </div>
     </div>
   );

--- a/components/Input/index.tsx
+++ b/components/Input/index.tsx
@@ -1,60 +1,14 @@
-import {
-  FontAwesomeIcon,
-  FontAwesomeIconProps,
-} from '@fortawesome/react-fontawesome';
-import { faUpload } from '@fortawesome/free-solid-svg-icons';
-import { useMemo, useState } from 'react';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { useMemo } from 'react';
+import { useFileInput, InputProps } from './hooks';
 import styles from './styles.module.css';
 
-interface InputProps {
-  label: string;
-  placeholder: string;
-  type: 'text' | 'email' | 'password' | 'number' | 'file';
-  value?: string;
-  onChange?: (event: React.ChangeEvent<HTMLInputElement>) => void;
-  icon?: FontAwesomeIconProps['icon'];
-}
-
-function Input({
-  label,
-  placeholder,
-  type,
-  value,
-  onChange,
-  icon,
-}: InputProps) {
+function Input(props: InputProps) {
+  const { type, label, placeholder, value } = props;
   const isFileInput = useMemo(() => type === 'file', [type]);
-  const [selectedFile, setSelectedFile] = useState<string | null>(null);
 
-  const renderedIcon = useMemo(() => {
-    if (type === 'file') {
-      return faUpload;
-    }
-
-    return icon;
-  }, [icon, type]);
-
-  const handleInputChange = (event: React.ChangeEvent<HTMLInputElement>) => {
-    if (isFileInput) {
-      const file = event.target.files?.[0];
-
-      if (file) {
-        setSelectedFile(file.name);
-      } else {
-        setSelectedFile(null);
-      }
-    }
-
-    onChange?.(event);
-  };
-
-  const fileInputId = useMemo(() => {
-    if (isFileInput) {
-      return label.replaceAll(' ', '-').toLowerCase();
-    }
-
-    return undefined;
-  }, [isFileInput, label]);
+  const { renderedIcon, fileInputId, handleInputChange, fileInputLabel } =
+    useFileInput(props);
 
   return (
     <div
@@ -72,7 +26,7 @@ function Input({
         {isFileInput && (
           <label htmlFor={fileInputId}>
             {renderedIcon && <FontAwesomeIcon icon={renderedIcon} />}
-            {selectedFile ? 'Documento selecionado.' : placeholder}
+            {fileInputLabel}
           </label>
         )}
         <input

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,12 +15,14 @@
         "next": "13.0.0",
         "next-pwa": "^5.6.0",
         "react": "18.2.0",
-        "react-dom": "18.2.0"
+        "react-dom": "18.2.0",
+        "react-input-mask": "^2.0.4"
       },
       "devDependencies": {
         "@types/node": "18.11.7",
         "@types/react": "18.0.24",
         "@types/react-dom": "18.0.8",
+        "@types/react-input-mask": "^3.0.2",
         "@typescript-eslint/eslint-plugin": "^5.42.1",
         "eslint": "8.26.0",
         "eslint-config-next": "13.0.0",
@@ -2264,6 +2266,15 @@
       "version": "18.0.8",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.0.8.tgz",
       "integrity": "sha512-C3GYO0HLaOkk9dDAz3Dl4sbe4AKUGTCfFIZsz3n/82dPNN8Du533HzKatDxeUYWu24wJgMP1xICqkWk1YOLOIw==",
+      "dev": true,
+      "dependencies": {
+        "@types/react": "*"
+      }
+    },
+    "node_modules/@types/react-input-mask": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/react-input-mask/-/react-input-mask-3.0.2.tgz",
+      "integrity": "sha512-WTli3kUyvUqqaOLYG/so2pLqUvRb+n4qnx2He5klfqZDiQmRyD07jVIt/bco/1BrcErkPMtpOm+bHii4Oed6cQ==",
       "dev": true,
       "dependencies": {
         "@types/react": "*"
@@ -4565,6 +4576,14 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/invariant": {
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
+      "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
+      "dependencies": {
+        "loose-envify": "^1.0.0"
+      }
+    },
     "node_modules/is-bigint": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/is-bigint/-/is-bigint-1.0.4.tgz",
@@ -5752,6 +5771,19 @@
         "react": "^18.2.0"
       }
     },
+    "node_modules/react-input-mask": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/react-input-mask/-/react-input-mask-2.0.4.tgz",
+      "integrity": "sha512-1hwzMr/aO9tXfiroiVCx5EtKohKwLk/NT8QlJXHQ4N+yJJFyUuMT+zfTpLBwX/lK3PkuMlievIffncpMZ3HGRQ==",
+      "dependencies": {
+        "invariant": "^2.2.4",
+        "warning": "^4.0.2"
+      },
+      "peerDependencies": {
+        "react": ">=0.14.0",
+        "react-dom": ">=0.14.0"
+      }
+    },
     "node_modules/react-is": {
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
@@ -6618,6 +6650,14 @@
       "integrity": "sha512-eEgnFxGQ1Ife9bzYs6VLi8/4X6CObHMw9Qr9tPY43iKwsPw8xE8+EFsf/2cFZ5S3esXgpWgtSCtLNS41F+sKPA==",
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
+    "node_modules/warning": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/warning/-/warning-4.0.3.tgz",
+      "integrity": "sha512-rpJyN222KWIvHJ/F53XSZv0Zl/accqHR8et1kpaMTD/fLCRxtV8iX8czMzY7sVZupTI3zcUTg8eycS2kNF9l6w==",
+      "dependencies": {
+        "loose-envify": "^1.0.0"
       }
     },
     "node_modules/watchpack": {
@@ -8578,6 +8618,15 @@
         "@types/react": "*"
       }
     },
+    "@types/react-input-mask": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/react-input-mask/-/react-input-mask-3.0.2.tgz",
+      "integrity": "sha512-WTli3kUyvUqqaOLYG/so2pLqUvRb+n4qnx2He5klfqZDiQmRyD07jVIt/bco/1BrcErkPMtpOm+bHii4Oed6cQ==",
+      "dev": true,
+      "requires": {
+        "@types/react": "*"
+      }
+    },
     "@types/resolve": {
       "version": "1.17.1",
       "resolved": "https://registry.npmjs.org/@types/resolve/-/resolve-1.17.1.tgz",
@@ -10247,6 +10296,14 @@
         "side-channel": "^1.0.4"
       }
     },
+    "invariant": {
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
+      "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
+      "requires": {
+        "loose-envify": "^1.0.0"
+      }
+    },
     "is-bigint": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/is-bigint/-/is-bigint-1.0.4.tgz",
@@ -11068,6 +11125,15 @@
         "scheduler": "^0.23.0"
       }
     },
+    "react-input-mask": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/react-input-mask/-/react-input-mask-2.0.4.tgz",
+      "integrity": "sha512-1hwzMr/aO9tXfiroiVCx5EtKohKwLk/NT8QlJXHQ4N+yJJFyUuMT+zfTpLBwX/lK3PkuMlievIffncpMZ3HGRQ==",
+      "requires": {
+        "invariant": "^2.2.4",
+        "warning": "^4.0.2"
+      }
+    },
     "react-is": {
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
@@ -11652,6 +11718,14 @@
       "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.2.0.tgz",
       "integrity": "sha512-eEgnFxGQ1Ife9bzYs6VLi8/4X6CObHMw9Qr9tPY43iKwsPw8xE8+EFsf/2cFZ5S3esXgpWgtSCtLNS41F+sKPA==",
       "requires": {}
+    },
+    "warning": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/warning/-/warning-4.0.3.tgz",
+      "integrity": "sha512-rpJyN222KWIvHJ/F53XSZv0Zl/accqHR8et1kpaMTD/fLCRxtV8iX8czMzY7sVZupTI3zcUTg8eycS2kNF9l6w==",
+      "requires": {
+        "loose-envify": "^1.0.0"
+      }
     },
     "watchpack": {
       "version": "2.4.0",

--- a/package.json
+++ b/package.json
@@ -16,12 +16,14 @@
     "next": "13.0.0",
     "next-pwa": "^5.6.0",
     "react": "18.2.0",
-    "react-dom": "18.2.0"
+    "react-dom": "18.2.0",
+    "react-input-mask": "^2.0.4"
   },
   "devDependencies": {
     "@types/node": "18.11.7",
     "@types/react": "18.0.24",
     "@types/react-dom": "18.0.8",
+    "@types/react-input-mask": "^3.0.2",
     "@typescript-eslint/eslint-plugin": "^5.42.1",
     "eslint": "8.26.0",
     "eslint-config-next": "13.0.0",

--- a/pages/cadastrar/index.tsx
+++ b/pages/cadastrar/index.tsx
@@ -47,9 +47,10 @@ export default function Register() {
 
         <Input
           icon={faPhone}
-          label="Telefone"
-          placeholder="(99) 9 9999-9999"
-          type="text"
+          label="Número do Whatsapp"
+          mask="(99) 9 9999-9999"
+          placeholder="(99) 9 4002-8922"
+          type="tel"
         />
 
         <Input


### PR DESCRIPTION
Adicionar máscaras nos inputs, você pode testar [na página de se cadastrar](https://joga-mais-git-feat-input-mask-es-grupo-2.vercel.app/cadastrar), no input de número do whatsapp.

<img width="386" alt="Screenshot 2022-11-22 at 21 14 19" src="https://user-images.githubusercontent.com/40612788/203446279-da4abb04-51c2-4d7f-8fda-08bae8f60ac0.png">

Eu passei as coisas relacionadas ao file input para um arquivo de hooks.ts, então tem 1 arquivo grande aí que pode ignorar, pq foi só mudar de um arquivo para outro. Já aprovamos PR sobre isso

### A mudança relevante:
```jsx
{mask ? (
  <InputMask
    mask={mask}
    type={type}
    value={value}
    placeholder={placeholder}
    onChange={handleInputChange}
  />
) : (
  <input
    id={fileInputId}
    type={type}
    placeholder={placeholder}
    value={value}
    onChange={handleInputChange}
  />
)}
```
